### PR TITLE
Docs suggestions

### DIFF
--- a/R/evaluateImmunogen.R
+++ b/R/evaluateImmunogen.R
@@ -7,7 +7,7 @@
 #' @export
 #'
 #' @description
-#' By calling `evaluateImmunogen()` the immunogens associated with a Protein DataFrame can be evaluated regarding
+#' By calling `evaluateImmunogen()`, the immunogens associated with a Protein DataFrame can be evaluated regarding
 #' their suitability fir antibody binding in natively folded proteins. By calling the function without specifying
 #' an immunogen, all immunogens of the current protein will be evaluated. The summary DataFrame contains one row per
 #' evaluated immunogen.

--- a/R/evaluateImmunogen.R
+++ b/R/evaluateImmunogen.R
@@ -9,7 +9,7 @@
 #' @description
 #' By calling `evaluateImmunogen()` the immunogens associated with a Protein DataFrame can be evaluated regarding
 #' their suitability fir antibody binding in natively folded proteins. By calling the function without specifying
-#' an immunogen all immunogens of the current protein will be evaluated. The summary DataFrame contains one row per
+#' an immunogen, all immunogens of the current protein will be evaluated. The summary DataFrame contains one row per
 #' evaluated immunogen.
 #'
 #' @examples

--- a/R/plotImmunogen.R
+++ b/R/plotImmunogen.R
@@ -5,8 +5,8 @@
 #'
 #' @description
 #' `plotImmunogen()` creates multiple ggplot objects within one figure. An Immunogen DataFrame is created by
-#' filtering the Protein DataFrame for the relevant immunogen segment. For each feature with annotations in
-#' the Immunogen DataFrame a plot is created. On the x axis the amino acid sequence of the immunogen is shown.
+#' filtering the Protein DataFrame for the relevant immunogen segment. A plot is created for each feature with annotations in
+#' the Immunogen DataFrame. The amino acid sequence of the immunogen is shown on the x axis.
 #'
 #'
 #' @return A ggplot object
@@ -18,7 +18,7 @@
 #' @examples
 #' proteinDF <- getProteinFeatures("P55087")
 #' proteinDF <- addImmunogen(proteinDF, start=10, end=30, name="A12")
-#' plotImmunogen(exampleDF, "A12")
+#' plotImmunogen(proteinDF, "A12")
 plotImmunogen <- function(proteinDF, immunogen) {
 
   # check for valid immunogen names

--- a/R/plotProtein.R
+++ b/R/plotProtein.R
@@ -3,8 +3,8 @@
 #' @param proteinDF Protein DataFrame created by call to getProteinFeatures()
 #'
 #' @description
-#' A call to `plotProtein()` visualized all relevant protein features within one figure along
-#' the entire protein sequence. All immunogen associated with the protein are highlighted at their
+#' A call to `plotProtein()` visualizes all relevant protein features within one figure along
+#' the entire protein sequence. All immunogens associated with the protein are highlighted at their
 #' position along the protein sequence by darkred boxes.
 #'
 #' @return A ggplot object


### PR DESCRIPTION
Few notes and minor suggestions about the documentation - we will discuss this during our meeting next Monday:
- Maybe this is expected, but the file [immunogenViewer_vignette.Rmd](https://github.com/kathiwaury/immunogenViewer/blob/docs_suggestions_gcroci2/vignettes/immunogenViewer_vignette.Rmd), which I guess will be the documentation visualized in Bioconductor, slightly differs from the pdf generated using `devtools::build_manual()`. 
- Even if you will publish this on Bioconductor, it would be nice to have an updated readme on GitHub. Some ideas:
   - Copy paste a basic description of the package from the docs.
   - While waiting the Bioconductor publication (only if this takes some time and you wish to make the repo public in the meantime), you could add instructions for cloning the repo, installing dev tools, and loading the package. Same thing for generating the PDF via RStudio (maybe even providing the PDF in the repo and mentioning it in the readme).
   - When it will be published, you could mention that the package is published on Bioconductor, link to that, and add the same instructions you have there to install it.  
- Start docs with `getProteinFeatures` rather than `addImmunogen`.  In the file I mentioned above, [immunogenViewer_vignette.Rmd](https://github.com/kathiwaury/immunogenViewer/blob/docs_suggestions_gcroci2/vignettes/immunogenViewer_vignette.Rmd), is already like this, but in the pdf generated via RStudio `addImmunogen` is the first functionality to be described. 
- In the docs, you could add links to UniProt and PredictProtein official websites
- The example `proteinDF <- addImmunogen(proteinDF, 10, 30, "A12")` gives "Immunogen sequence not found in the protein sequence." error. But if I use `proteinDF <- addImmunogen(proteinDF, start=10, end=30, name="A12")`, all works fine. 